### PR TITLE
Bin: multitailc > color support by shell wildcards

### DIFF
--- a/bin/multitailc
+++ b/bin/multitailc
@@ -1,0 +1,6 @@
+#!/bin/bash
+args=""
+for file in "$@"; do
+    args+="-cT ANSI $file "
+done
+multitail $args

--- a/install.py
+++ b/install.py
@@ -51,6 +51,7 @@ tasks = {
     '~/.local/bin/imgls' : 'bin/imgls',
     '~/.local/bin/fzf' : '~/.fzf/bin/fzf', # fzf is at $HOME/.fzf
     '~/.local/bin/tb' : 'bin/tb',
+    '~/.local/bin/multitailc' : 'bin/multitailc',
 
     # X
     '~/.Xmodmap' : 'Xmodmap',


### PR DESCRIPTION
Just Type, `multitailc *.log`

Example case.

![image](https://user-images.githubusercontent.com/4136228/30195437-54a601f6-9494-11e7-91cd-4ff8c4c64686.png)

