### PR TITLE
Several improvements to Build System

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -36,6 +36,7 @@ if vim.fn.has('nvim-0.7') == 0 then
 end
 
 require 'config/commands'
+require 'config/quickfix'
 
 -- Source individiual rc files. (lazy loading)
 function RC.source_config_lazy()

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -35,6 +35,7 @@ if vim.fn.has('nvim-0.7') == 0 then
   return
 end
 
+require 'config/ui'
 require 'config/commands'
 require 'config/quickfix'
 

--- a/nvim/lua/config/commands.lua
+++ b/nvim/lua/config/commands.lua
@@ -1,3 +1,4 @@
 -- Custom Lua-based commands
 
 require 'config/commands/Config'
+require 'config/commands/Makeprg'

--- a/nvim/lua/config/commands/Makeprg.lua
+++ b/nvim/lua/config/commands/Makeprg.lua
@@ -1,0 +1,62 @@
+-- This would override :Makeprg, :MakeprgLocal defined in vimrc
+
+local M = {}
+
+-- Define commands upon sourcing
+-- :Makeprg, :MakeprgGlobal, :MakeprgLocal
+vim.api.nvim_create_user_command(
+  'Makeprg', function(opts) M.SetMakeprg(opts.args) end,
+  { nargs = '?', desc = 'Change &g:makeprg or &l:makeprg.' })
+vim.api.nvim_create_user_command(
+  'MakeprgGlobal', function(opts) M.SetMakeprg(opts.args, "g") end,
+  { nargs = '?', desc = 'Change (global) &l:makeprg.' })
+vim.api.nvim_create_user_command(
+  'MakeprgLocal', function(opts) M.SetMakeprg(opts.args, "l") end,
+  { nargs = '?', desc = 'Change (local) &l:makeprg.' })
+
+
+function M.SetMakeprg(args, mode)
+  if mode == nil then  -- auto determine, 'l' iff &l:makeprg is set
+    mode = string.len(vim.opt_local.makeprg:get() or "") > 0 and 'l' or 'g'
+  end
+
+  -- mode: 'g' or 'l'
+  local vim_opt = (mode == 'g') and vim.opt_global or vim.opt_local
+  local confirm_change = function()
+    print(string.format("%s:makeprg = ", mode) .. vim_opt.makeprg:get())
+  end
+
+  args = args or ""
+  if args ~= "" then
+    vim_opt.makeprg = args
+    confirm_change()
+    return
+  end
+
+  local prompt = string.format("Enter the new &%s:makeprg command", mode)
+  if mode == 'l' then
+    prompt = prompt .. string.format(' (for the buffer %s)', vim.fn.bufname())
+  end
+  prompt = prompt .. " >"
+
+  local CANCEL_SENTINEL = "___!!!@@@CANCELLED@@@!!!___"
+  vim.ui.input({
+    prompt = prompt,
+    default = vim_opt.makeprg:get(),
+    cancelreturn = CANCEL_SENTINEL,  -- see dressing.nvim#72
+  }, function(new_value)
+    if new_value == CANCEL_SENTINEL then
+      return  -- Interrupted or canceled, different from ""
+    end
+    new_value = vim.trim(new_value or "")
+    if new_value ~= "" or mode == 'l' then
+      -- Change either g:makeprg or l:makeprg
+      vim_opt.makeprg = new_value
+      -- Save to history so that any previous changes can be restored
+      vim.fn.histadd("cmd", (mode == 'g' and "MakeprgGlobal" or "MakeprgLocal") .. " " .. new_value)
+    end
+    confirm_change()
+  end)
+end
+
+return M

--- a/nvim/lua/config/quickfix.lua
+++ b/nvim/lua/config/quickfix.lua
@@ -1,0 +1,67 @@
+-- config/quickfix.lua
+
+-- [[ nvim-bqf ]]
+if not pcall(require, 'bqf') then
+  print("Warning: telescope not available, skipping configuration.")
+  return
+end
+
+local M = {}
+
+-- [[ Useful commands and keys (https://github.com/kevinhwang91/nvim-bqf#function-table)
+--     zf: Enter the fzf search mode
+-- ]]
+
+M.setup_bqf = function()
+  -- https://github.com/kevinhwang91/nvim-bqf#setup-and-description
+  -- https://github.com/kevinhwang91/nvim-bqf#advanced-configuration
+  require "bqf".setup {
+    auto_enable = true,
+
+    preview = {
+      should_preview_cb = function(bufnr, qf_winid)
+        local bufname = vim.api.nvim_buf_get_name(bufnr)
+        if bufname:match('^fugitive://') then return false end
+        return true
+      end,
+    },
+
+    func_map = {
+      -- Do not map <C-b> <C-f> in the quickfix window
+      pscrolldown = '',
+      pscrollup = '',
+    },
+  }
+
+  do  -- Highlights for the preview window
+    vim.cmd [[
+
+      " use more discernable colors
+      highlight!      BqfPreviewFloat       guibg=#1a2a31
+      highlight! link BqfPreviewBorder      BqfPreviewFloat
+      " do not highlight cursors in the preview window
+      highlight! link BqfPreviewCursor      BqfPreviewFloat
+
+    ]]
+  end
+end
+
+
+-- Custom commands (local) on the quickfix windowfix window
+M.setup_qf_commands = function()
+  vim.cmd [[
+    augroup bqfQuickfixWindow
+      autocmd!
+      " :FZF, :Grep, :Filter (zf) actions
+      autocmd FileType qf command! -buffer  FZFQuickfix  lua require('bqf.filter.fzf').run()
+      autocmd FileType qf command! -buffer  Grep         FZFQuickfix
+      autocmd FileType qf command! -buffer  FZF          FZFQuickfix
+      autocmd FileType qf command! -buffer  Filter       FZFQuickfix
+
+      " :Clean
+    augroup END
+  ]]
+end
+
+M.setup_bqf()
+M.setup_qf_commands()

--- a/nvim/lua/config/statusline.lua
+++ b/nvim/lua/config/statusline.lua
@@ -63,7 +63,13 @@ local custom_components = {
     local ret, _ = vim.bo.fileformat:gsub("^unix$", "")
     return ret
   end,
-  -- neomake job status
+  -- asyncrun & neomake job status
+  asyncrun_status = function()
+    return table.concat(vim.tbl_values(vim.tbl_map(function(job)
+      if job.status == 'running' then return '⏳' end
+      return (job.status == 'success' and '✅' or '❌')
+    end, vim.g.asyncrun_job_status or {})))
+  end,
   neomake_status = function()
     return table.concat(vim.tbl_values(vim.tbl_map(function(job)
       if job.exit_code == nil then return '⏳' end
@@ -106,6 +112,7 @@ require('lualine').setup {
       { 'branch', cond = min_statusline_width(120) },
     },
     lualine_c = {
+      custom_components.asyncrun_status,
       custom_components.neomake_status,
       { 'filename', path = 1, color = { fg = '#eeeeee' } },
       { custom_components.treesitter_context },

--- a/nvim/lua/config/ui.lua
+++ b/nvim/lua/config/ui.lua
@@ -1,0 +1,21 @@
+-- config/ui.lua
+-- Settings for UI-related components.
+
+if pcall(require, 'dressing') then
+  -- Prettier vim.ui.select() and vim.ui.input()
+
+  -- https://github.com/stevearc/dressing.nvim#configuration
+  require 'dressing'.setup {
+
+    input = {
+      -- the greater of 140 columns or 90% of the width
+      prefer_width = 80,
+      max_width = { 140, 0.9 },
+    },
+
+    select = {
+    },
+
+  }
+
+end

--- a/vim/after/ftplugin/cpp.vim
+++ b/vim/after/ftplugin/cpp.vim
@@ -6,7 +6,12 @@
 " ====================
 
 " Show <Quickfix List> buffer at the right splitted vertically
-command! -buffer -bar Copen   cclose | vertical 60copen | wincmd w
+command! -count=60 -buffer Copen   call s:Copen(<count>)
+function! s:Copen(count) abort
+    cclose
+    exec printf('vertical %dcopen', a:count)
+    wincmd h
+endfunction
 
 " Automatic makeprg generation (regarding %:r.in, %r.ans)
 if !filereadable('Makefile')

--- a/vim/after/ftplugin/cpp.vim
+++ b/vim/after/ftplugin/cpp.vim
@@ -6,11 +6,7 @@
 " ====================
 
 " Show <Quickfix List> buffer at the right splitted vertically
-if isdirectory(expand("~/.vim/plugged/vim-dispatch"))
-    noremap <F6> <ESC>:cclose<CR>:TheCopen<CR>:wincmd L<CR>:setlocal nowfh<CR>:70wincmd \|<CR>:wincmd h<CR>
-else
-    noremap <F6> <ESC>:cclose<CR>:vertical 60copen<CR>:wincmd h<CR>
-endif
+command! -buffer -bar Copen   cclose | vertical 60copen | wincmd w
 
 " Automatic makeprg generation (regarding %:r.in, %r.ans)
 if !filereadable('Makefile')

--- a/vim/after/ftplugin/lilypond.vim
+++ b/vim/after/ftplugin/lilypond.vim
@@ -1,6 +1,8 @@
 " Lilypond filetype plugin
 " overrides vim-lilypond-integrator plugin
 
+" Do not use lilypond.vim's ftplugin mappings
+" see ~/.vim/plugged/vim-polyglot/ftplugin/lilypond.vim
 silent! unmap <buffer> <F5>
 silent! unmap <buffer> <F6>
 

--- a/vim/after/ftplugin/lua.vim
+++ b/vim/after/ftplugin/lua.vim
@@ -1,10 +1,9 @@
 " Use tab size of 2.
 setlocal ts=2 sts=2 sw=2
 
-" <F5> action: source it, if a (neo)vim config
+" <F5> or :Make ==> source it, if a (neo)vim config
 if expand("%:p") =~ "nvim/lua/config/"
-  noremap <buffer> <F5>
-        \ <cmd>source %<CR><cmd>call VimNotify("Sourced " . bufname('%'))<CR>
+  command! -buffer -bar  Build   w | source % | call VimNotify("Sourced " . bufname('%'))
 endif
 
 " Make goto-file (gf, ]f) detect lua config files.

--- a/vim/after/ftplugin/python.vim
+++ b/vim/after/ftplugin/python.vim
@@ -166,9 +166,10 @@ endfunction
 " pytest or execute the script itself, as per &makeprg
 let s:is_test_file = (expand('%:t:r') =~# "_test$" || expand('%:t:r') =~# '^test_')
 if has_key(g:plugs, 'neotest-python') && s:is_test_file
-  noremap <buffer>     <F5>       <cmd>:NeotestRun<CR>
-  noremap <buffer>     <F6>       <cmd>:NeotestOutput<CR>
-  noremap <buffer>     <F7>       <cmd>lua require'neotest'.run.attach()<CR>
+  " see ~/.config/nvim/config/tesing.lua commands
+  command! -buffer -nargs=0  Build    echom ':Test' | Test
+  command! -buffer -nargs=0  Output   NeotestOutput
+  noremap <buffer>           <F7>    <cmd>lua require'neotest'.run.attach()<CR>
 
 elseif has_key(g:plugs, 'vim-floaterm')
   let s:ftname = 'makepython'
@@ -209,6 +210,7 @@ elseif has_key(g:plugs, 'vim-floaterm')
       wincmd p        " move back to the python buf
     endif
   endfunction
-  noremap <buffer>          <F5>   <ESC>:w<CR>:<C-u>call MakeInTerminal()<CR><C-\><C-o>:stopinsert<CR>
-  noremap <buffer> <silent> <F6>   :FloatermToggle makepython<CR>
+  " <F5> Build (replaces Make), <F6> Output (replaces QuickfixToggle)
+  command! -buffer -bar  Build   w | call MakeInTerminal() | stopinsert
+  command! -buffer -bar  Output  FloatermShow makepython
 endif

--- a/vim/after/syntax/qf.vim
+++ b/vim/after/syntax/qf.vim
@@ -1,0 +1,9 @@
+" highlight the very first line (\%1l)
+syntax match qfMakeCommand  /\%1l.*/
+hi def link qfMakeCommand  Special
+
+syntax match qfFinishedSuccess '^|| \[Finished in \d\+ seconds\]$'
+syntax match qfFinishedError   '^|| \[Finished in \d\+ seconds with code \d*\]$'
+
+hi! qfFinishedSuccess  guifg=#37b24d
+hi! qfFinishedError    guifg=#f03e3e

--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -67,6 +67,9 @@ Plug 'jistr/vim-nerdtree-tabs', { 'on': g:_nerdtree_lazy_events }
 Plug 'Xuyuanp/nerdtree-git-plugin'
 
 Plug 'vim-voom/VOoM', { 'on' : ['Voom', 'VoomToggle'] }
+if has('nvim')
+   Plug 'kevinhwang91/nvim-bqf'
+endif
 if has('nvim') || v:version >= 800
   Plug 'neomake/neomake'
   Plug 'skywind3000/asyncrun.vim'

--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -67,7 +67,6 @@ Plug 'jistr/vim-nerdtree-tabs', { 'on': g:_nerdtree_lazy_events }
 Plug 'Xuyuanp/nerdtree-git-plugin'
 
 Plug 'vim-voom/VOoM', { 'on' : ['Voom', 'VoomToggle'] }
-Plug 'tpope/vim-dispatch', { 'tag' : 'v1.1' }
 if has('nvim') || v:version >= 800
   Plug 'neomake/neomake'
 endif

--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -71,6 +71,7 @@ if has('nvim') || v:version >= 800
   Plug 'neomake/neomake'
   Plug 'skywind3000/asyncrun.vim'
 endif
+Plug 'vim-scripts/errormarker.vim'
 if has('nvim')
   Plug 'gelguy/wilder.nvim', { 'do': function('UpdateRemote') }
   Plug 'romgrk/fzy-lua-native'

--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -69,6 +69,7 @@ Plug 'Xuyuanp/nerdtree-git-plugin'
 Plug 'vim-voom/VOoM', { 'on' : ['Voom', 'VoomToggle'] }
 if has('nvim') || v:version >= 800
   Plug 'neomake/neomake'
+  Plug 'skywind3000/asyncrun.vim'
 endif
 if has('nvim')
   Plug 'gelguy/wilder.nvim', { 'do': function('UpdateRemote') }

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -566,22 +566,26 @@ command! -nargs=* -bar Debug    Make
 " Note that filetype plugins or individual buffers may override the command :Make
 " For instance, ~/.vim/after/ftplugin/python.vim  ~/.vim/after/ftplugin/cpp.vim
 "
-" TODO: Neomake doesn't support regular Makefile args
-" TODO: Real-time streaming of progress & output upon request. Neomake does not support this.
-command! -nargs=0 -bar Make    call s:run_make("<bang>")
-function! s:run_make(bang)
+command! -nargs=* -complete=customlist,MakeCommandCompletion -bar Make
+      \ call s:run_make("<bang>", <q-args>)
+function! s:run_make(bang, qargs)
     " Asynchronous job dispatching in the background (output goes to quickfix)
-    AsyncMake
-    "Neomake!
+    exec 'AsyncMake ' . a:qargs
     echohl Special
     echom 'Make: ' . &makeprg
     echohl NONE
 endfunction
 
-if !has_key(g:plugs, 'neomake')
-  " fallback to the plain make if neomake is not there
-  command! -nargs=0 -bang Neomake     cexpr [] | make<bang>
-end
+" Completion for :Make commands
+function! MakeCommandCompletion(A, L, P) abort
+  if &makeprg == 'make'
+    " credit: @pbnj https://dev.to/pbnj/how-to-get-make-target-tab-completion-in-vim-4mj1
+    let l:targets = systemlist('make -qp | awk -F'':'' ''/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}'' | grep -v Makefile | sort -u')
+    return filter(l:targets, 'v:val =~ "^' . a:A . '"')
+  else
+    return []
+  end
+endfunction
 
 " A handy way to set (global) makeprg.
 command! -nargs=1 Makeprg let &g:makeprg="<args>" | echo "makeprg = <args>"
@@ -1567,8 +1571,8 @@ let g:airline#extensions#whitespace#mixed_indent_algo = 1
 " Settings
 let g:asyncrun_open = 0   " Do not open quickfix after job starts
 
-command! -nargs=* AsyncMake  call AsyncMake(<q-args>)
-" TODO: Makefile completion depending on &makeprg
+command! -nargs=* -complete=customlist,MakeCommandCompletion AsyncMake
+      \ call AsyncMake(<q-args>)
 function! AsyncMake(qarg) abort
   let l:qarg = (a:qarg)
   if &makeprg == 'make'

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1568,8 +1568,12 @@ let g:airline#extensions#whitespace#mixed_indent_algo = 1
 " Note that asyncrun.vim allows only one job running at a time.
 " For multiple job dispatch, we may need more advanced plugins.
 
-" Settings
-let g:asyncrun_open = 0   " Do not open quickfix after job starts
+" (Settings)
+" Do not open quickfix after job starts
+let g:asyncrun_open = 0
+" Trigger autocmd QuickFixCmdPost make after job finish (triggers errormarker)
+let g:asyncrun_auto = "make"
+
 
 command! -nargs=* -complete=customlist,MakeCommandCompletion AsyncMake
       \ call AsyncMake(<q-args>)
@@ -1737,6 +1741,22 @@ augroup END
 
 " }
 
+
+" ---------------------------------------------------------------- }}}
+" errormarker.vim (quickfix to signs) {{{
+
+" signs
+let g:errormarker_errortext = '✘'
+let g:errormarker_warningtext = ''
+let g:errormarker_errortextgroup = "DiagnosticSignError"
+let g:errormarker_warningtextgroup = "DiagnosticSignWarn"
+
+" text line
+let g:errormarker_errorgroup = 'ErrormarkerErrorText'
+let g:errormarker_warninggroup = 'ErrormarkerWarningText'
+
+hi ErrormarkerErrorText       guibg=#3d0f0f
+hi ErrormarkerWarningText     guibg=NONE
 
 " ---------------------------------------------------------------- }}}
 " FZF {{{

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1633,6 +1633,19 @@ function! OnAsyncRunJobFinished() abort
   endif
 endfunction
 
+" Actions in the asyncrun window
+augroup AsyncRunQuickfixWindow
+  autocmd!
+  " Ctrl-C twice: kill the asyncrun job
+  autocmd FileType qf    noremap <silent> <nowait> <buffer> <C-C>        <cmd>echo 'Press Ctrl-C twice to kill the job'<CR>
+  autocmd FileType qf    noremap <silent> <nowait> <buffer> <C-C><C-C>   <cmd>call AsyncrunQuickfixCtrlC()<CR>
+augroup END
+function! AsyncrunQuickfixCtrlC() abort
+  if g:asyncrun_status == "running"
+    AsyncStop
+  endif
+endfunction
+
 
 " ---------------------------------------------------------------- }}}
 " Neomake (deprecated) {{{

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -588,7 +588,10 @@ function! MakeCommandCompletion(A, L, P) abort
 endfunction
 
 " A handy way to set (global) makeprg.
-command! -nargs=1 Makeprg let &g:makeprg="<args>" | echo "makeprg = <args>"
+" See ~/.dotfiles/nvim/lua/config/commands/Makeprg.lua for nvim+lua version
+command! -nargs=1 Makeprg       let &makeprg="<args>" | echo "&makeprg = <args>"
+command! -nargs=1 MakeprgGlobal let &g:makeprg="<args>" | echo "&g:makeprg = <args>"
+command! -nargs=1 MakeprgLocal  let &l:makeprg="<args>" | echo "&l:makeprg = <args>"
 
 
 " Make for vim script files is to reload itself.

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -570,8 +570,9 @@ command! -nargs=* -bar Debug    Make
 " TODO: Real-time streaming of progress & output upon request. Neomake does not support this.
 command! -nargs=0 -bar Make    call s:run_make("<bang>")
 function! s:run_make(bang)
-    cexpr []
-    Neomake!   " asynchronous job dispatching in the background
+    " Asynchronous job dispatching in the background (output goes to quickfix)
+    AsyncMake
+    "Neomake!
     echohl Special
     echom 'Make: ' . &makeprg
     echohl NONE
@@ -579,7 +580,7 @@ endfunction
 
 if !has_key(g:plugs, 'neomake')
   " fallback to the plain make if neomake is not there
-  command! -nargs=0 -bang Neomake     make<bang>
+  command! -nargs=0 -bang Neomake     cexpr [] | make<bang>
 end
 
 " A handy way to set (global) makeprg.
@@ -613,11 +614,14 @@ command! -nargs=0 -bar  QuickfixToggle  call QuickfixToggle()
 function! QuickfixToggle() abort
   let nr = winnr('$')
   :Copen
+  cbottom   " scroll the quickfix window to the last line
   let nr2 = winnr('$')
   if nr == nr2 | cclose | endif
 endfunction
 
-command! -nargs=0 -bar  Copen   copen
+" Open the quickfix window scroll to the end (to see the status)
+" Note: asyncrun will override Copen later with asyncrun#quickfix_toggle
+command! -nargs=0 -bar       Copen   copen
 
 
 " <leader>L: show/close location list window
@@ -1554,7 +1558,41 @@ let g:airline#extensions#tabline#show_buffers = 1
 let g:airline#extensions#whitespace#mixed_indent_algo = 1
 
 " ---------------------------------------------------------------- }}}
-" Neomake {{{
+" asyncrun.vim {{{
+" see ~/.vim/after/syntax/qf.vim for color + highlights
+
+" Note that asyncrun.vim allows only one job running at a time.
+" For multiple job dispatch, we may need more advanced plugins.
+
+" Settings
+let g:asyncrun_open = 0   " Do not open quickfix after job starts
+
+command! -nargs=* AsyncMake  call AsyncMake(<q-args>)
+" TODO: Makefile completion depending on &makeprg
+function! AsyncMake(qarg) abort
+  let l:qarg = (a:qarg)
+  if &makeprg == 'make'
+    exe 'AsyncRun make ' . l:qarg
+  else
+    if !empty(l:qarg)
+      echohl WarningMsg |
+      echo 'Error: Cannot have arguments with &makeprg = ' . &makeprg
+      echohl None
+      return
+    endif
+    exe 'AsyncRun ' . ExpandCmd(&makeprg)
+  endif
+endfunction
+
+" Copen. Do not steal the cursor.
+command! -bar -count=9 Copen   call asyncrun#quickfix_toggle(<count>, v:true)
+
+" Alias :Run => :AsyncRun
+call CommandAlias('Run', 'AsyncRun', v:true)
+
+
+" ---------------------------------------------------------------- }}}
+" Neomake (deprecated) {{{
 
 " so that ':Neomake clean' invokes 'make clean'
 let g:neomake_clean_maker = { 'exe': 'make', 'args': ['clean'] }

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1590,6 +1590,49 @@ command! -bar -count=9 Copen   call asyncrun#quickfix_toggle(<count>, v:true)
 " Alias :Run => :AsyncRun
 call CommandAlias('Run', 'AsyncRun', v:true)
 
+" asyncrun autocmd events: notification callback when job finishes
+augroup AsyncRunEvents
+  autocmd!
+  autocmd User AsyncRunStart  call OnAsyncRunJobStart()
+  autocmd User AsyncRunStop   call OnAsyncRunJobFinished()
+augroup END
+
+let g:asyncrun_job_status = {}
+function! OnAsyncRunJobStart() abort
+  let l:jobid = 3000   " asyncrun supports only ONE concurrent job
+  let g:asyncrun_job_status[l:jobid] = {
+        \ 'status': 'running',
+        \ 'cmdline': g:asyncrun_info,
+        \ }
+endfunction
+
+function! OnAsyncRunJobFinished() abort
+  let l:jobid = 3000   " asyncrun supports only ONE concurrent job
+  let l:job = get(g:asyncrun_job_status, l:jobid, {})
+  if l:job == {} | return | endif
+  let l:job['status'] = g:asyncrun_status
+
+  " Notifications.
+  if l:job['status'] != "success"
+    let l:failure_message = l:job['cmdline']
+    let l:job_title = printf("AsyncRun")   " TODO: How to get the cmd or job info?
+    call VimNotify('Job Failed: ' . l:failure_message, 'warn', {'title': l:job_title})
+
+    " Automatically show quickfix window if the job has failed.
+    " open the qf window at the bottom (regardless of overriden :Copen)
+    call asyncrun#quickfix_toggle(9, v:true) | cbottom
+  endif
+
+  " Statusline integration
+  " Remove the job from the statusline after 2 seconds
+  if !exists('*timer_start')
+    silent! unlet g:asyncrun_job_status[l:jobid]
+  else
+    call timer_start(2000, { -> execute(printf(
+          \"silent! unlet g:asyncrun_job_status[%d]", l:jobid)) })
+  endif
+endfunction
+
 
 " ---------------------------------------------------------------- }}}
 " Neomake (deprecated) {{{
@@ -1626,10 +1669,10 @@ function! s:OnNeomakeJobFinished()
 
   " Remove the job from the statusline after 2 seconds
   if !exists('*timer_start')
-    unlet g:neomake_job_status[l:context.jobinfo.make_id]
+    silent! unlet g:neomake_job_status[l:context.jobinfo.make_id]
   else
     call timer_start(2000, { -> execute(printf(
-          \"unlet g:neomake_job_status[%d]", l:context.jobinfo.make_id)) })
+          \"silent! unlet g:neomake_job_status[%d]", l:context.jobinfo.make_id)) })
   endif
 
   let l:bufnr = l:context.jobinfo.bufnr
@@ -1640,13 +1683,13 @@ function! s:OnNeomakeJobFinished()
   if l:exit_code != 0
     let l:failure_message = printf('%s%s ', l:failure_message, l:job['as_string']())
   endif
-  if !empty(l:failure_message)
+  if !empty(l:failure_message)  " fail
     call VimNotify('Job Failed: ' . l:failure_message, 'warn', {'title': l:job_title})
     copen | wincmd p   " copen, but not move to the quickfix window
     if !s:is_copen()
       let b:neomake_auto_copen = 1
     endif
-  else
+  else  " job success
     if g:neomake_job_notification > 0
       call VimNotify('Job Finished, Success.', 'info',
             \ {'title': l:job_title, 'timeout': 1000})

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -1563,6 +1563,10 @@ let g:airline#extensions#tabline#show_buffers = 1
 let g:airline#extensions#whitespace#mixed_indent_algo = 1
 
 " ---------------------------------------------------------------- }}}
+" nvim-bqf (enhanced quickfix) {{{
+" See ~/.dotfiles/nvim/lua/config/quickfix.lua
+
+" ---------------------------------------------------------------- }}}
 " asyncrun.vim {{{
 " see ~/.vim/after/syntax/qf.vim for color + highlights
 

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -642,6 +642,7 @@ map <F4> <ESC>:cn<CR>
 map [26~ <ESC>:cp<CR>
 map [1;2S <ESC>:cp<CR>
 map [29~ <ESC>:cp<CR>
+map <S-F4> <ESC>:cp<CR>
 
 " [F2] save
 imap <F2> <ESC>:w<CR>

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -535,53 +535,56 @@ vnoremap > >gv
 nnoremap [l :lprevious<CR>
 nnoremap ]l :lnext<CR>
 
-" -----------------------
-" [F5] Make and Build {{{
-" -----------------------
-" use Make (vim-dispatch) or Neomake (neomake)
-if has_key(g:plugs, 'neomake')
-    " neomake; always use the bang version so that :copen can sync
-    command! -nargs=0 -bang TheMake cexpr [] | Neomake!
-    command! -nargs=0 TheCopen copen
-else
-    " vim-dispatch
-    command! -nargs=0 -bang TheMake Make<bang>
-    command! -nargs=0 TheCopen Copen
-endif
+" ------------------
+" Make and Build {{{
+" ------------------
+" We use <F5> and <Ctrl-F5> to quickly build and execute the code.
+" <C-F5> :Build        => Build and run the program.
+" <F5>   :Debug        => Build and run, in a debug mode (with DAP in the future) if available.
+" <F6>   :Output       => Show the output or build status window (quickfix, terminal, etc.)
 
+" To specialize project-wise, filetype-wise, or buffer-wise behaviors,
+" the Build, Debug, and Output commands be overriden.
+" However, we should NOT directly remap <F5> and <Ctrl-F5>.
 
-" smartly dispatch according to filetype
-command! -nargs=0 -bang RunMake call s:run_make("<bang>")
+" For now, <F5> runs :Debug -> :Build -> :Make.
+nmap <F5>    <cmd>silent w<CR><cmd>Debug<CR>
+nmap <C-F5>  <cmd>silent w<CR><cmd>Build<CR>
+imap <F5>    <ESC><F5>a
+imap <C-F5>  <ESC><C-F5>a
+
+" Alternative to <F5> (shortcut)
+map <leader>m <F5>
+
+" Build commands default to Make
+command! -nargs=* -bar Build    Make
+command! -nargs=* -bar Debug    Make
+
+" :Make
+" The default behavior is to run :Neomake, which runs a &makeprg job silently in the background.
+"
+" Note that filetype plugins or individual buffers may override the command :Make
+" For instance, ~/.vim/after/ftplugin/python.vim  ~/.vim/after/ftplugin/cpp.vim
+"
+" TODO: Neomake doesn't support regular Makefile args
+" TODO: Real-time streaming of progress & output upon request. Neomake does not support this.
+command! -nargs=0 -bar Make    call s:run_make("<bang>")
 function! s:run_make(bang)
-    let l:silent_filetypes = ['tex', 'pandoc', 'lilypond']
-    " (1) bang given, force background
-    if a:bang ==# '!' | TheMake!
-    " (2) for specified filetypes, use background
-    elseif index(l:silent_filetypes, &filetype) >= 0 | TheMake!
-    " (3) otherwise, make with foreground shown
-    else | TheMake
-    endif
-    echo printf(':RunMake  (%s)', &makeprg)
+    cexpr []
+    Neomake!   " asynchronous job dispatching in the background
+    echohl Special
+    echom 'Make: ' . &makeprg
+    echohl NONE
 endfunction
 
-" A handy way to set makeprg.
+if !has_key(g:plugs, 'neomake')
+  " fallback to the plain make if neomake is not there
+  command! -nargs=0 -bang Neomake     make<bang>
+end
+
+" A handy way to set (global) makeprg.
 command! -nargs=1 Makeprg let &g:makeprg="<args>" | echo "makeprg = <args>"
 
-if has_key(g:plugs, 'vim-dispatch')
-    " use vim-dispatch if exists
-
-    " <F5>: run make, asynchronously or split windows (dispatch)
-    map  <F5> <ESC>:w<CR>:RunMake<CR>
-    imap <F5> <ESC><F5>a
-
-    " <leader-F5>: run make with visible progress (split window in tmux)
-    map  <leader><F5> <ESC>:w<CR>:RunMake!<CR>
-
-else
-    " otherwise, fallback to default make
-    map <F5> <ESC>:w<CR>:make!<CR>
-    imap <F5> <ESC><F5>a
-endif
 
 " Make for vim script files is to reload itself.
 augroup VimscriptMakeprg
@@ -590,21 +593,32 @@ augroup VimscriptMakeprg
         \ <cmd>source %<CR><cmd>call VimNotify("Sourced " . bufname('%'))<CR>
 augroup END
 
-" Alternative to <F5>
-map <leader>m <F5>
-
 " }}}
 
-" <F6>: show/close quickfix window (scroll bottom)
-function! QuickfixToggle()
+
+" :OutputToggle or <F6> (Toggle mode)
+" -----------------------------
+
+" F6 :Output
+map  <silent> <F6>   <cmd>Output<CR>
+imap <silent> <F6>   <c-\><c-o><F6>
+":call QuickfixToggle()<CR>G:wincmd w<CR>a
+nmap <silent> <C-Q>  :call QuickfixToggle()<CR>
+
+" By default, :Output opens or closes the quickfix (copen) window
+" filetype plugin or individual buffers may override the command :Output (or :COpen)
+command! -nargs=0 -bar  Output          QuickfixToggle
+command! -nargs=0 -bar  QuickfixToggle  call QuickfixToggle()
+
+function! QuickfixToggle() abort
   let nr = winnr('$')
-  :TheCopen
+  :Copen
   let nr2 = winnr('$')
   if nr == nr2 | cclose | endif
 endfunction
-map  <silent> <F6> :call QuickfixToggle()<CR>
-imap <silent> <F6> <ESC>:call QuickfixToggle()<CR>G:wincmd w<CR>a
-nmap  <silent> <C-Q> :call QuickfixToggle()<CR>
+
+command! -nargs=0 -bar  Copen   copen
+
 
 " <leader>L: show/close location list window
 function! LocListToggle()
@@ -2122,8 +2136,8 @@ hi def link FloatermBorderNF  FloatermBorder
 command! -bang -nargs=? -complete=shellcmd  T                    :FloatermToggleOrNew<bang> <args>
 command! -bang -nargs=? -complete=shellcmd  FT                   :FloatermToggleOrNew<bang> <args>
 command! -bang -nargs=? -complete=shellcmd  FloatermToggleOrNew  call FloatermToggleOrNew(<q-args>, <bang>0)
-nnoremap <leader>tt  :FloatermToggle<CR>
-"
+nnoremap <leader>tt  :FloatermToggleOrNew<CR>
+
 function! FloatermToggleOrNew(...) abort
   " FloatermToggleOrNew(cmdline: str, bang: int = 0)
   "  - if bang=1, run the command in a shell use sendkeys.


### PR DESCRIPTION
* Keymaps:
  - `<C-F5>` `:Build`   => Build and run the program. Defaults to `:Make`
  - `<F5>`   `:Debug`   => Build and run, in a debug mode (when DAP is introduced later). Defaults to `:Build`
  - `<F6>`   `:Output`  => Show the quickfix or terminal window. Defaults to `:ToggleQuickfix`


* Per-filetype or Per-buffer behavior specialization: Override command `:Build`,` :Debug`, or `:Output`

* Replace vim-dispatch and neomake (obsolte...) with asyncrun.vim:  Real-time progress output to the quickfix window

* asyncrun.nvim: `:Make [args]`, `:AsyncRun [shell cmd]`


<details>
<summary>Demo GIF / Screenshots</summary>

<img src="https://user-images.githubusercontent.com/1009873/198866663-bbdeb31e-9609-492b-8c1a-0c57cc74548a.gif" width="600" />

</details>




