### PR TITLE
zsh: Rewrite how $PATH are configured in zsh startup scripts

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -99,7 +99,9 @@ else
 fi
 
 # PATH for local settings
-export PATH="~/.local/bin/:$PATH"
+if [[ ! "$PATH" == *~/.local/bin* ]]; then
+  export PATH="~/.local/bin:$PATH"
+fi
 
 # Additional Completion
 if [ -f /usr/local/etc/bash_completion ]; then source /usr/local/etc/bash_completion; fi

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -72,9 +72,16 @@ endif
 " use path '~/.vim' even on non-unix machine
 set runtimepath+=~/.vim
 
-" add ~/.local/bin and ~/.dotfiles/bin to $PATH
-let $PATH .= ':' . expand('~/.local/bin')
-let $PATH .= ':' . expand('~/.dotfiles/bin')
+" Add ~/.local/bin and ~/.dotfiles/bin to $PATH even if haven't (e.g., using bash shell)
+" See ~/.zshenv for a proper $PATH configuration.
+function! s:ensure_PATH(dir) abort
+  let l:dir = expand(a:dir)
+  if match(":" . $PATH . ":", ":" . l:dir, ":") < 0
+    let $PATH = l:dir . ":" . $PATH
+  endif
+endfunction
+call s:ensure_PATH('~/.local/bin')
+call s:ensure_PATH('~/.dotfiles/bin')
 
 " load plugins with pathogen
 try

--- a/zsh/zprofile
+++ b/zsh/zprofile
@@ -1,4 +1,16 @@
-# Start-up script executed if a login shell.
+# ~/.zprofile
+#
+# Start-up script executed if an "interactive login shell"
+#
+# Note: not executed when doing `exec zsh`; it's a non-login shell
+#
+# Execution order:
+#   ~/.zshenv -> [/etc/zprofile] -> ~/.zprofile -> ~/.zshrc -> ~/.zlogin
+#                 (*)                ^^^^^^^^^^^
+#
+# WARNING: on macOS, /etc/zprofile messes up $PATH.
+# See [fighting with path_helper] https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2#order-is-key-and-everything-
+
 
 # set default permission of file to 644 (rw-r--r--)
 umask 022
@@ -6,25 +18,9 @@ umask 022
 # Against "Too many open files"; default value (256) is too low
 ulimit -n 10240
 
-# At this point, /etc/zprofile has been executed (after ~/.zshenv)
-# which messes up $PATH due to the execution of `path_helper`.
-# Correct $PATH so that /usr/local/bin, etc. would come after
-# custom, local-preferred paths.
-path=( ${path[@]:#/usr/local/bin} )
-path=( ${path[@]:#/usr/local/sbin} )
-path=( ${path[@]:#/usr/bin} )
-path=( ${path[@]:#/usr/sbin} )
-path=( ${path[@]:#/sbin} )
-path=(
-  $path
-  "/usr/local/bin"
-  "/usr/local/sbin"
-  "/usr/bin"
-  "/usr/sbin"
-  "/sbin"
-)
 
-# Let ~/.local/bin take precedence
-if ! (( ${path[(I)$HOME/.local/bin]} )); then
-  path=( $HOME/.local/bin $path )
-fi
+# (*) WARNING: on macOS, /etc/zprofile messes up $PATH.
+# This should have been disabled by disabling /etc/zprofile (see ~/.zshenv).
+# See [fighting with path_helper] https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
+
+# vim: set ft=zsh ts=2 sts=2 sw=2:

--- a/zsh/zsh.d/alias.zsh
+++ b/zsh/zsh.d/alias.zsh
@@ -9,8 +9,7 @@ _version_check() {
 # -----------------------------
 
 # Basic
-alias reload!="command -v antidote 2>&1 > /dev/null && antidote reset; \
-    source ~/.zshrc && echo 'sourced ~/.zshrc' again"
+alias reload!="command -v antidote 2>&1 > /dev/null && antidote reset; exec zsh --login"
 alias c='command'
 alias ZQ='exit'
 alias QQ='exit'

--- a/zsh/zsh.d/envs.zsh
+++ b/zsh/zsh.d/envs.zsh
@@ -60,29 +60,9 @@ if (( $+commands[nvim] )) && [[ -z "$GIT_EDITOR" ]] ; then
 fi
 
 #
-# Path Configurations.
+# Path Configurations: Removed, DON'T PUT HERE.
 #
-# Note: Configuring $PATH should be done preferably in ~/.zshenv,
-# in order that zsh plugins are also provisioned with exectuables from $PATH.
-# Entries listed here may not be visible from zsh plugins and source scripts.
-
-# Rust (cargo) {{{
-path=( $path $HOME/.cargo/bin )
-# }}}
-
-# GO {{{
-
-# $GOPATH is where go-installed libraries or command line utilities will be installed.
-# Especially, binaries will be located at $HOME/.go/bin, which should be added to $PATH.
-export GOPATH=$HOME/.go
-mkdir -p $GOPATH
-path=( $path $GOPATH/bin )
-
-# }}}
-
-# Bazel {{{
-if [ -f $HOME/.bazel/bin/bazel ]; then
-  export BAZEL_HOME="$HOME/.bazel"
-  path=( $path $BAZEL_HOME/bin )
-fi
-# }}}
+# Note: Configuring $PATH should be done preferably in:
+#   ~/.zshenv    (available even for non-login shells and scripts as well as interactive shells)
+#   ~/.zshrc     (available only for interactive (login or non-login) shells)
+#

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -1,8 +1,18 @@
+# ~/.zshenv
 #
-# Defines environment variables.
+# Defines environment variables for ZSH.
+# **ALWAYS** sourced first on interactive, login, non-login (script) shells.
+#
+#   ~/.zshenv -> ~/.zprofile -> ~/.zshrc -> ~/.zlogin
+#   ^^^^^^^^^
+#
+# See [fighting with path_helper] https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
+# See https://unix.stackexchange.com/questions/71253/what-should-shouldnt-go-in-zshenv-zshrc-zlogin-zprofile-zlogout
+# TL;DR) $PATH for interactive shell configs should be in ~/.zprofile
 #
 # See also: ~/.zsh/zsh.d/envs.zsh
 #
+
 #
 # Authors:
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
@@ -37,65 +47,93 @@ if [[ "$LC_CTYPE" == "UTF-8" ]]; then
   export LC_CTYPE='en_US.UTF-8'
 fi
 
+# DO NOT run system startup files (e.g., /etc/zprofile, /etc/zshrc, /etc/zsh/*, etc.).
+# This is important to prevent the problematic /etc/zprofile from messing up $PATH (on macOS).
+# On Linux systems, it won't matter as $PATH are not corrupted by /etc/zprofile.
+# A consequence is that /etc/path, /etc/paths.d/*, are no longer added to the $PATH by default,
+# so these would need to be added manually by this user startup file (~/.zshenv).
+# Also, system-wide zshrc (e.g., /etc/zshrc) would need to be manually sourced in ~/.zshrc.
+# see: https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
+unsetopt GLOBAL_RCS
+
 #
-# Paths
+# Paths ($PATH, $path)
 #
 
 typeset -gU cdpath fpath mailpath path
 
-# [For Mac M1 USERS]
-# Homebrew: /opt/homebrew/bin must precede /usr/local/bin.
-# Please update /etc/paths: add `/opt/homebrew/bin` manually.
+# NOTE: the order is *VERY* important, should be defined in the order of
+#  increasing importance and precedence so that we can "prepend" directories to $path.
+#  It's also important to NOT prepend if already included in $path,
+#  because some PATH entry for subshell or subprocess can be shadowed.
+# NOTE: paths for interactive shells should go into ~/.zshrc
+#
 
-if ! (( $path[(I)/opt/homebrew/bin] )); then
-    # Add homebrew bin path to $path automatically, if
-    # /etc/paths is not sourced or not configured.
-    path=($path /opt/homebrew/bin)
+function prepend_path() {
+  # prepend to $PATH, only if the directory exists and is not already included.
+  local p; for p in "$@"; do
+    if [ -d "$p" ] && (( ! ${path[(I)$p]} )); then
+      path=( $p $path )
+    fi
+  done
+}
+
+
+# Add macOS system path (see the "disabled" /etc/zprofile)
+# Note: since path_helper always prepend, it can mess up the order if
+# $PATH is inherited from a parent env (e.g., tmux, nested shell, etc.).
+# So we make a backup before calling it to have the current $path prioritized
+# and those "system path" (e.g., /usr/local/bin) always come after user-config.
+if [ -x /usr/libexec/path_helper ]; then
+  local -a path_orig=($path)
+  eval `/usr/libexec/path_helper -s`
+  path=($path_orig $path)
 fi
 
-# Set the the list of directories that cd searches.
-# cdpath=(
-#   $cdpath
-# )
+# [For Apple Silicon (M1, M2) USERS]
+# Homebrew: /opt/homebrew/bin must precede /usr/local/bin, etc.
+# NOTE: It's also recommended to put /opt/homebrew/bin to /etc/path
+# for non-zsh programs (e.g., GUI apps and some bash scripts).
 
-# Set the list of directories that Zsh searches for programs.
-# see ~/.zprofile as well
-path=(
-  $path
-  /usr/local/{bin,sbin}
-)
-
-# Let ~/.local/bin take precedence
-if ! (( ${path[(I)$HOME/.local/bin]} )); then
-  path=( $HOME/.local/bin $path )
-fi
-
-# Additional $PATH configuration:
-
-# dotfiles-populated bin.
-if [ -d $HOME/.dotfiles/bin/ ]; then
-  path=( $path $HOME/.dotfiles/bin )
+if [[ $(uname) == "Darwin" ]] && [[ $(uname -m) == "arm64" ]]; then
+  prepend_path "/opt/homebrew/bin"
+  # Homebrew ruby is keg-only, no links at /opt/homebrew/bin.
+  # Note that we need to pin an exact version of ruby
+  prepend_path "/opt/homebrew/opt/ruby@3.0/bin"
+  prepend_path "/opt/homebrew/lib/ruby/gems/3.0.0/bin"
 fi
 
 # Node + Yarn
-if [ -d $HOME/.yarn/bin/ ]; then
-  path=( $path $HOME/.yarn/bin )
+prepend_path "$HOME/.yarn/bin"
+
+# GO
+# $GOPATH is where go-installed libraries or command line utilities will be installed.
+# Especially, binaries will be located at $HOME/.go/bin, which should be added to $PATH.
+export GOPATH=$HOME/.go
+mkdir -p $GOPATH
+prepend_path "$GOPATH/bin"
+
+# rust (cargo)
+prepend_path "$HOME/.cargo/bin"
+
+# Bazel {{{
+if [ -f "$HOME/.bazel/bin/bazel" ]; then
+  export BAZEL_HOME="$HOME/.bazel"
+  prepend_path "$BAZEL_HOME/bin"
 fi
 
-# Ruby on macos (M1)
-# Homebrew ruby is keg-only, no symlink into /opt/homebrew/bin,
-# so we'll need manually add ruby and gem bins to PATH
-# NOTE: We hvae to pin an exact ruby version (brew install ruby@3.0)
-if [[ "$OSTYPE" == darwin* && "$(uname -m)" == "arm64" ]]; then
-  path=(
-    "/opt/homebrew/opt/ruby@3.0/bin"
-    "/opt/homebrew/lib/ruby/gems/3.0.0/bin"
-    $path
-  )
-fi
+# dotfiles-populated bin (having quite high priority)
+prepend_path "$HOME/.dotfiles/bin"
+
+# Let ~/.local/bin take the most, biggest precedence
+prepend_path "$HOME/.local/bin"
 
 # Cleanup some conda environment variables to avoid messing up in tmux, etc.
 # (these environment variables might be copied and inherited unwantedly)
+if [[ -n "$CONDA_PREFIX" ]]; then
+  # remove all $PATH entry for the current conda env
+  path=(${(@)path:#${CONDA_PREFIX}*})
+fi
 unset CONDA_EXE
 unset CONDA_PREFIX
 unset CONDA_DEFAULT_ENV
@@ -110,26 +148,23 @@ function _try_conda_base() {
     return 0;  # do nothing, CONDA_EXE is already found
   fi
 
-  if [ -d "$conda_base" ]; then
-    path=( $path "$conda_base/bin" )
+  if [ -d "$conda_base/bin" ]; then
+    prepend_path "$conda_base/bin"
     export CONDA_EXE="$conda_base/bin/conda"
     if [ ! -f "$CONDA_EXE" ]; then
       echo "Warning: $CONDA_EXE does not exist"
     fi
+    return 0;
   fi
+  return 1;
 }
 
-_try_conda_base "$HOME/.miniforge3";
-_try_conda_base "$HOME/miniforge3";
-_try_conda_base "$HOME/.miniconda3";
-_try_conda_base "$HOME/miniconda3";
-_try_conda_base "/usr/local/miniconda3";
+_try_conda_base "$HOME/.miniforge3" || \
+_try_conda_base "$HOME/miniforge3"  || \
+_try_conda_base "$HOME/.miniconda3" || \
+_try_conda_base "$HOME/miniconda3"  || \
+_try_conda_base "/usr/local/miniconda3" || true;
 unfunction _try_conda_base
-
-# rust (cargo)
-if [ -d $HOME/.cargo/bin/ ]; then
-  path=( $path $HOME/.cargo/bin )
-fi
 
 
 #
@@ -186,7 +221,12 @@ fi
 # as some linux systems zsh might be locally-installed on ~/.local/share (like a site config)
 #   but on other systems ~/.local may be treated as user-local config.
 #
-fpath=(${ZDOTDIR:-$HOME}/.zsh/prezto-themes ~/.zsh/functions ~/.local/share/zsh/site-functions $fpath)
+fpath=(
+  ${ZDOTDIR:-$HOME}/.zsh/prezto-themes
+  $HOME/.zsh/functions
+  $HOME/.local/share/zsh/site-functions
+  $fpath   # e.g. /usr/local/share/zsh/site-functions
+)
 
 
 #
@@ -221,3 +261,21 @@ export COPYFILE_DISABLE=true
 if [ -f "$HOME/.zshenv.local" ]; then
   source "$HOME/.zshenv.local"
 fi
+
+
+# Enforce system-wide PATH entries to be put at the back, always
+# (this can correct some PATH issues for subshell or subprocess)
+# Note: see ~/.zprofile and ~/.zshrc
+path=( ${path[@]:#/usr/local/bin} )
+path=( ${path[@]:#/usr/local/sbin} )
+path=( ${path[@]:#/usr/bin} )
+path=( ${path[@]:#/usr/sbin} )
+path=( ${path[@]:#/bin} )
+path=( ${path[@]:#/sbin} )
+path=(
+  $path
+  /usr/local/{bin,sbin}
+  /usr/{bin,sbin}
+  /bin
+  /sbin
+)

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -182,6 +182,9 @@ fi
 #
 # Add custom config directory.
 #  (note that this line is executed before initialization of prezto.)
+# TODO: This is not the right place to configure "custom" $fpath,
+# as some linux systems zsh might be locally-installed on ~/.local/share (like a site config)
+#   but on other systems ~/.local may be treated as user-local config.
 #
 fpath=(${ZDOTDIR:-$HOME}/.zsh/prezto-themes ~/.zsh/functions ~/.local/share/zsh/site-functions $fpath)
 

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -145,6 +145,14 @@ fi
 
 # }}} ===================
 
+# Fix inconsistent fpath order (workaround for antidote#157)
+# system-wide zsh site-functions (/usr/local/share/zsh/, /opt/homebrew/share/zsh, etc.)
+# should come AFTER local and antidote paths.
+# some zsh magic: https://stackoverflow.com/questions/3435355/remove-entry-from-array
+fpath_user=(${(@)fpath:#/(opt|usr)/*zsh*})   # remove all /opt, /usr path
+fpath_system=(${(@)fpath:|fpath_user})       # $fpath \setminus $fpath_system
+fpath=($fpath_user $fpath_system)
+
 # fzf
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -1,6 +1,21 @@
 # .zshrc
 # ======
+#
+# zshrc is sourced for "interactive" shells (either non-login or login)
 # vim: set sts=2 sw=2 ts=2
+
+#   ~/.zshenv -> ~/.zprofile -> [/etc/zshrc] -> ~/.zshrc -> ~/.zlogin
+#                                               ^^^^^^^^
+#
+# See [fighting with path_helper] https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
+# See https://github.com/rbenv/rbenv/wiki/Unix-shell-initialization
+# See https://unix.stackexchange.com/questions/71253/what-should-shouldnt-go-in-zshenv-zshrc-zlogin-zprofile-zlogout
+# See https://medium.com/@rajsek/zsh-bash-startup-files-loading-order-bashrc-zshrc-etc-e30045652f2e
+
+# Note that we have unsetopt GLOBAL_RCS in ~/.zshenv
+if [ -f /etc/zshrc ]; then source /etc/zshrc; fi
+if [ -f /etc/zsh/zshrc ]; then source /etc/zsh/zshrc; fi
+
 
 # To profile zsh startup, use the following:
 # In ~/.zshrc,
@@ -154,6 +169,7 @@ fpath_system=(${(@)fpath:|fpath_user})       # $fpath \setminus $fpath_system
 fpath=($fpath_user $fpath_system)
 
 # fzf
+(( ! ${path[(I)$HOME/.fzf/bin]} )) && path=( $HOME/.fzf/bin $path )
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
 # Manually source fzf-git.sh *after* fzf
@@ -233,3 +249,6 @@ fi
 if [ -f "$HOME/.zshrc.local" ]; then
     source "$HOME/.zshrc.local"
 fi
+
+
+# vim: set ts=2 sts=2 sw=2:


### PR DESCRIPTION
## zsh: Rewrite how $PATH are configured in zsh startup scripts

**Changes**:

`$PATH` (or `$path` in zsh) configurations for zsh shell and scripts are unified and all moved to `~/.zshenv`, from previously being scattered at many different places without a clear sense about what-goes-where.

This could be a more principled solution to the very annoying problem where $PATH being messed up in nested shells and tmux sessions, etc. (see also 97370d32, d7c7cad6, 1fd48b324 for more context and history).

With the following changes, we are now able to have a *consistent* `$PATH` environment regardless of whether we are opening a new terminal, using tmux, using a sub-shell (either interactive or non-interactive) where `$PATH` is set as inherited from the parent shell, etc.

**Problem and Solution**: (1) Fix broken `$PATH` on macOS

- The crux of the problem is that, on macOS, `$PATH` is messed up by having the "system, global" path entries from `/etc/paths` such as `/usr/bin`, `/bin` are always prepended. (see the ⚠️  mark below and ["fighting with path_helper"][1])

- To prevent this from happening, we disable sourcing global RC files (`/etc/zprofile`, `/etc/zshrc`, etc.) and take care of them manually if needed. This also makes the behavior consistent with other Linux systems.

**Problem and Solution**: (2) Configure `$path` in the right place.

- In short, user-scope `$path` are added and configured in `~/.zshenv` if they should be visible by both *interactive-shells and scripts*. 
- Some `$path` entries that should be used *only* for interactive shells  (but not for scripts) can lie in `~/.zshrc` (not in `~/.zprofile`), for the sake of performance. Note that `~/.zshenv` is sourced by all scripts, so it should be quite fast.
- Adding a path entry is done in such a manner that it's *prepended* to `$path`, buf only if it's not already included in the `$path`. If we always prepend, the path order set by other sources or plugins (e.g., anaconda or virtual environments) can be inconsistent in nested shells. This is not to shadow any `$PATH` entries inherited from the parent shell or process.


**Background Knowledge**: How does zsh startup work?

FYI, the execution order of zsh startup scripts is (see [zsh manual][2]):

       zshenv   (always)
    -> zprofile (if login shell, -l)
    -> zshrc    (if interactive, -i)
    -> zlogin   (if login shell, -l)

Or more specifically, consider the following four cases:

  - **(1) `-l`, `-i`: interactive, login**
    - The usual case. Example: open a new terminal, enter a new SSH session, or open a new tmux window/pane.
  - **(2) `-i`      : interactive, non-login**
    - Example: `zsh` or `exec zsh` on an existing interactive shell, or opening a terminal window inside a neovim
  - **(3) (script)  : non-interactive, non-login**
    - Example: Run a script (e.g., `zsh -c "ls"`). Also includes some GUI apps with `SHELL=zsh`.
  - **(4) `-l`**    : non-interactive, login (this is not usual)
    - Example: `echo ... | ssh server`, `zsh -l -c "ls"`

|                  | sourced when |⑴ `-l`,`-i`|⑵ `-i`|⑶ (script)|⑷ `-l`|
| ---------------- |:-------------|:----------|:-----|:---------|------|
| 1. /etc/zshenv   | always       |    ✅     |  ✅  |    ✅    |  ✅  |
| 2. ~/.zshenv     | always       |    ✅     |  ✅  |    ✅    |  ✅  |
| 3. /etc/zprofile | login ⚠️      |    ✅*    |      |          |  ✅  |
| 4. ~/.zprofile   | login        |    ✅     |      |          |  ✅  |
| 5. /etc/zshrc    | interactive  |    ✅*    |  ✅* |          |      |
| 6. ~/.zshrc      | interatcive  |    ✅     |  ✅  |          |      |
| 7. /etc/zlogin   | login        |    ✅*    |      |          |  ✅* |
| 8. ~/.zlogin     | login        |    ✅     |      |          |  ✅  |

Legend:
  - ✅    : will be sourced (if exists)
  - ✅*   : `/etc/*` (or `/etc/zsh/*`) are only if `GLOBAL_RCS` is set.
  - ⚠️     : on macOS, `path_helper` will mess up `$PATH`, adding the system paths (e.g., `/usr/bin`, `/bin`) frontmost to `$PATH`. See ["fighting with path_helper"][1].
  - (note) Options like `--norc`, `--rcfile`, `--noprofile`, etc. are not considered.

**References:**

- [zsh manual "STARTUP/SHUTDOWN FILES"][2]
- [About interactive, non-interactive, login, non-login shells][3]
- [Unix Stackexchange: What should/shouldn't go in .zshenv, .zshrc, .zlogin, .zprofile, .zlogout?][4]

[1]: https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2
[2]: https://zsh.sourceforge.io/Doc/Release/Files.html
[3]: https://askubuntu.com/questions/879364/differentiate-interactive-login-and-non-interactive-non-login-shell
[4]: https://unix.stackexchange.com/questions/71253/what-should-shouldnt-go-in-zshenv-zshrc-zlogin-zprofile-zlogout



## zsh: Fix incorrect $fpath ordering

antidote puts `$fpath` entries for the zsh plugins after the system site-functions path.

Since we want custom shell completions shipped with zsh plugins, we manually fix the order of $fpath after sourcing all the antidote plugins as a workaround.

