### PR TITLE
vim(treesitter): Change `has-type?` to `kind-eq?` to align with upstream

### DIFF
--- a/nvim/after/queries/lua/folds.scm
+++ b/nvim/after/queries/lua/folds.scm
@@ -13,7 +13,7 @@
 ;   also relevant: tree-sitter/tree-sitter#2468
 (
   ; The following somehow doesn't work for a very long comments. Might be a bug?
-  ; (_) @_non_comment (#not-has-type? @_non_comment comment)
+  ; (_) @_non_comment (#not-kind-eq? @_non_comment comment)
   [
     (function_declaration)
     (assignment_statement)

--- a/nvim/after/queries/python/folds.scm
+++ b/nvim/after/queries/python/folds.scm
@@ -14,10 +14,10 @@
   . [(import_statement) (import_from_statement) (future_import_statement) (comment)]*
   . [(import_statement) (import_from_statement) (future_import_statement)]+ @_end
   ; ... until the first non-import node.
-  . (_)  @_non_import1  (#not-has-type? @_non_import1  import_statement import_from_statement future_import_statement)
+  . (_)  @_non_import1  (#not-kind-eq? @_non_import1  import_statement import_from_statement future_import_statement)
   ; However, don't match if followed by another import statement,
   ; to ensure the capture group is maximial and avoid nested foldings.
-  . (_)? @_non_import2  (#not-has-type? @_non_import2  import_statement import_from_statement future_import_statement)
+  . (_)? @_non_import2  (#not-kind-eq? @_non_import2  import_statement import_from_statement future_import_statement)
 
   (#make-range! "fold" @_start @_end)
 )


### PR DESCRIPTION
There was a breaking change from `nvim-treesitter`.

https://github.com/nvim-treesitter/nvim-treesitter/pull/6716

This PR is to fix the issue