### PR TITLE
etc/linux-local: Fix incompatible bash syntax

### DIFF
--- a/etc/linux-locals.sh
+++ b/etc/linux-locals.sh
@@ -183,7 +183,7 @@ install_ncurses() {
 install_zsh() {
   local ZSH_VER="5.8"
   local TMP_ZSH_DIR="$DOTFILES_TMPDIR/zsh/"; mkdir -p "$TMP_ZSH_DIR"
-  local ZSH_SRC_URL = "https://sourceforge.net/projects/zsh/files/zsh/${ZSH_VER}/zsh-${ZSH_VER}.tar.xz/download"
+  local ZSH_SRC_URL="https://sourceforge.net/projects/zsh/files/zsh/${ZSH_VER}/zsh-${ZSH_VER}.tar.xz/download"
 
   wget -nc -O $TMP_ZSH_DIR/zsh.tar.xz "$ZSH_SRC_URL"
   tar xvJf "$TMP_ZSH_DIR/zsh.tar.xz" -C "$TMP_ZSH_DIR" --strip-components 1


### PR DESCRIPTION
`local x = "1"` doesn't work on bash/zsh. This PR is to fix the issue